### PR TITLE
Single argument get

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "bluebird": "^2.9.9",
         "lodash": "^3.2.0",
+        "node-tech-logger": "git://github.com/AirVantage/node-tech-logger.git#1.0.0",
         "node-tech-ruuid": "git://github.com/AirVantage/node-tech-ruuid.git#1.0.0",
         "node-tech-time": "git://github.com/AirVantage/node-tech-time.git#1.0.0",
         "request": "^2.53.0"

--- a/techHttp.js
+++ b/techHttp.js
@@ -3,6 +3,7 @@ var BPromise = require("bluebird");
 var events = require("events");
 var techRuuid = require("node-tech-ruuid");
 var techTime = require("node-tech-time");
+var logger = require("node-tech-logger");
 
 module.exports = function(mockRequest) {
 
@@ -14,7 +15,7 @@ module.exports = function(mockRequest) {
 
         techRuuid.check(ruuid);
 
-        category = category || "AppCore";
+        category = category || "core";
 
         var start = techTime.start();
 
@@ -42,17 +43,43 @@ module.exports = function(mockRequest) {
 
     }
 
+    /**
+     * Simpler form of get
+     *
+     * @param options.url
+     * @param [options.category]
+     * @param [options.timeout]
+     * @param [options.auth]
+     * @param [options.headers]
+     *
+     * Options object is also passed as such to the 'request' library'
+     */
+    function getFromOpts(ruuid, opts) {
+        logger.info("[tech-http] Getting from opts", opts);
+        return wrapRequest(ruuid, "getAsync", _.extend({
+            json : true
+        }, opts));
+    }
+
     return {
         on: emitter.on.bind(emitter),
 
         // TODO [JLE] 'timeout' and 'auth' should be removed and declared instead directly in the given 'options' parameter
         get: function wrapGet(ruuid, url, category, timeout, auth, options) {
-            return wrapRequest(ruuid, "getAsync", _.extend({
-                url: url,
-                json: true,
-                auth: auth,
-                timeout: timeout
-            }, options), category);
+
+            if (!_.isString(url) && arguments.length === 2) {
+                var opts = url;
+                return getFromOpts(ruuid, opts);
+            } else {
+                return wrapRequest(ruuid, "getAsync", _.extend({
+                    url: url,
+                    json: true,
+                    auth: auth,
+                    timeout: timeout
+                }, options), category);
+
+            }
+
         },
 
         // TODO [JLE] 'timeout' and 'auth' should be removed and declared instead directly in the given 'options' parameter

--- a/techHttp.js
+++ b/techHttp.js
@@ -57,8 +57,8 @@ module.exports = function(mockRequest) {
     function getFromOpts(ruuid, opts) {
         logger.info("[tech-http] Getting from opts", opts);
         return wrapRequest(ruuid, "getAsync", _.extend({
-            json: true
-        }, opts));
+            json : true
+        }, opts), opts.category);
     }
 
     return {

--- a/techHttp.js
+++ b/techHttp.js
@@ -57,7 +57,7 @@ module.exports = function(mockRequest) {
     function getFromOpts(ruuid, opts) {
         logger.info("[tech-http] Getting from opts", opts);
         return wrapRequest(ruuid, "getAsync", _.extend({
-            json : true
+            json: true
         }, opts));
     }
 

--- a/test/techHttpSpec.js
+++ b/test/techHttpSpec.js
@@ -5,15 +5,35 @@ var BPromise = require("bluebird");
 
 describe("tech-http", function() {
 
+    it("accepts get with a single arg", function () {
+        var mockRequest = {
+            getAsync : function (url, opts) {
+                assert.equal(url, "http://foo:8080/api/bar/baz");
+                assert.equal(opts.headers["X-foo"], "bar");
+                return BPromise.resolve([{
+                    statusCode : 200
+                }, {}]);
+            }
+        };
+
+        var http = techHttp(mockRequest);
+
+        return http.get("avop-ruuid-45", {
+            url : "http://foo:8080/api/bar/baz",
+            headers : {
+                "X-foo" : "bar"
+            }
+        });
+
+    });
+
     it("measures the duration of a call", function() {
 
         // Ad-hoc mock for the 'request' library
         var mockRequest = {
             getAsync: function(url, opts) {
-
                 assert.equal(url, "http://foo:8080/api/bar/baz", "Url should be set");
                 assert.ok(opts.json, "Json should be requested");
-
                 // Simulate a requests that takes a few milliseconds to run
                 return new BPromise(function(resolve, reject) {
                     setTimeout(function() {
@@ -37,7 +57,7 @@ describe("tech-http", function() {
 
         return http.get("avop-ruuid-42", "http://foo:8080/api/bar/baz").then(function(result) {
             assert.ok(result.foo === "bar", "request apis should have been wrapped");
-            assert.ok(parseFloat(duration.ms) > 100, "the request time should have been logged");
+            assert.ok(parseFloat(duration.ms) > 90, "the request time should have been logged");
             assert.ok(parseFloat(duration.ms) < 250, "the request time should not be that huge !");
 
         }, function(error) {

--- a/test/techHttpSpec.js
+++ b/test/techHttpSpec.js
@@ -5,13 +5,13 @@ var BPromise = require("bluebird");
 
 describe("tech-http", function() {
 
-    it("accepts get with a single arg", function () {
+    it("accepts get with a single arg", function() {
         var mockRequest = {
-            getAsync : function (url, opts) {
+            getAsync: function(url, opts) {
                 assert.equal(url, "http://foo:8080/api/bar/baz");
                 assert.equal(opts.headers["X-foo"], "bar");
                 return BPromise.resolve([{
-                    statusCode : 200
+                    statusCode: 200
                 }, {}]);
             }
         };
@@ -19,9 +19,9 @@ describe("tech-http", function() {
         var http = techHttp(mockRequest);
 
         return http.get("avop-ruuid-45", {
-            url : "http://foo:8080/api/bar/baz",
-            headers : {
-                "X-foo" : "bar"
+            url: "http://foo:8080/api/bar/baz",
+            headers: {
+                "X-foo": "bar"
             }
         });
 

--- a/test/techHttpSpec.js
+++ b/test/techHttpSpec.js
@@ -5,23 +5,27 @@ var BPromise = require("bluebird");
 
 describe("tech-http", function() {
 
-    it("accepts get with a single arg", function() {
+    it("accepts get with a single arg", function () {
         var mockRequest = {
-            getAsync: function(url, opts) {
+            getAsync : function (url, opts) {
                 assert.equal(url, "http://foo:8080/api/bar/baz");
                 assert.equal(opts.headers["X-foo"], "bar");
                 return BPromise.resolve([{
-                    statusCode: 200
+                    statusCode : 200
                 }, {}]);
             }
         };
 
         var http = techHttp(mockRequest);
 
+        http.on("http", function(what) {
+            assert.equal(what.category, "cat");
+        });
         return http.get("avop-ruuid-45", {
-            url: "http://foo:8080/api/bar/baz",
-            headers: {
-                "X-foo": "bar"
+            url : "http://foo:8080/api/bar/baz",
+            category : "cat",
+            headers : {
+                "X-foo" : "bar"
             }
         });
 


### PR DESCRIPTION
get can now be called with a single object for all options.

Yes, I should theorically have added that for all verbs. Not now.