### PR TITLE
PLTFRS-10328: Cleanup node-tech-perf-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "bluebird": "^2.9.9",
     "lodash": "^4.16.0",
-    "node-tech-ruuid": "git://github.com/AirVantage/node-tech-ruuid.git#1.x",
     "node-tech-time": "git://github.com/AirVantage/node-tech-time.git#1.x",
     "request": "^2.53.0"
   },

--- a/techHttp.js
+++ b/techHttp.js
@@ -1,7 +1,6 @@
 var _ = require('lodash');
 var BPromise = require('bluebird');
 var events = require('events');
-var techRuuid = require('node-tech-ruuid');
 var techTime = require('node-tech-time');
 
 module.exports = function(mockRequest) {
@@ -10,8 +9,6 @@ module.exports = function(mockRequest) {
   var emitter = new events.EventEmitter();
 
   function wrapRequest(ruuid, fnName, options, category) {
-    techRuuid.check(ruuid);
-
     category = category || 'core';
 
     var start = techTime.start();


### PR DESCRIPTION
https://issues.sierrawireless.com/browse/PLTFRS-10328

This removes the check for `ruuid` which will not be set after `node-tech-perf-logger` removal and allows applications to continue running without too much changes.

Plus some formatting courtesy of Prettier :grin: 